### PR TITLE
add AWS binderhub link

### DIFF
--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'https://mybinder.org',
+        url: 'https://binder.rudaux.com',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',

--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'https://binder.rudaux.com/',
+        url: 'https://binder.rudaux.com',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',

--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'https://binder.mds.rudaux.com',
+        url: 'https://mybinder.org',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',

--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'https://mybinder.org',
+        url: 'http://a35df4baf37fd4a0ebbe04b06c456cf0-367883518.ca-central-1.elb.amazonaws.com',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',

--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'http://35.203.106.253',
+        url: 'https://binder.rudaux.com/',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',

--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'http://a35df4baf37fd4a0ebbe04b06c456cf0-367883518.ca-central-1.elb.amazonaws.com',
+        url: 'http://35.203.106.253',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',

--- a/src/components/juniper.js
+++ b/src/components/juniper.js
@@ -16,7 +16,7 @@ class Juniper extends React.Component {
     static defaultProps = {
         children: '',
         branch: 'master',
-        url: 'https://binder.rudaux.com',
+        url: 'https://binder.mds.rudaux.com',
         serverSettings: {},
         kernelType: 'python3',
         lang: 'python',


### PR DESCRIPTION
This is a test bed for integrating a custom BinderHub, opening as a draft PR so it can't be merged. I want to leverage Netlify's deploy preview for testing purposes.